### PR TITLE
Make API endpoints more RESTful

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -26,6 +26,8 @@ class SociProductSerializer(serializers.Serializer):
 
 
 class CheckBalanceSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True, label="This soci bank account ID")
+
     user = serializers.CharField(read_only=True, label="User´s full name")
 
     balance = serializers.IntegerField(source='public_balance', read_only=True, allow_null=True, label="Balance in NOK",

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,11 +1,13 @@
 from django.urls import path, include
 
-from api.views import SociProductListView, SociBankAccountBalanceDetailView, ChargeSociBankAccountView
+from api.views import SociProductListView, SociBankAccountBalanceDetailView, SociBankAccountChargeView
 
 urlpatterns = [
     path('economy/', include([
-        path('products/', SociProductListView.as_view(), name='products'),
-        path('balance/', SociBankAccountBalanceDetailView.as_view(), name='check-balance'),
-        path('charge/', ChargeSociBankAccountView.as_view(), name='charge'),
+        path('products', SociProductListView.as_view(), name='products'),
+        path('bank-accounts/', include([
+            path('balance', SociBankAccountBalanceDetailView.as_view(), name='balance'),
+            path('<int:id>/charge', SociBankAccountChargeView.as_view(), name='charge'),
+        ])),
     ])),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -1,7 +1,8 @@
-from drf_yasg.openapi import Parameter, IN_HEADER, TYPE_INTEGER
+from drf_yasg.openapi import Parameter, IN_QUERY, TYPE_STRING
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
-from rest_framework.generics import get_object_or_404, ListAPIView, RetrieveAPIView
+from rest_framework.exceptions import ValidationError
+from rest_framework.generics import ListAPIView, RetrieveAPIView, get_object_or_404
 from rest_framework.response import Response
 
 from api.serializers import CheckBalanceSerializer, SociProductSerializer, ChargeSociBankAccountDeserializer, \
@@ -17,7 +18,10 @@ class SociProductListView(ListAPIView):
     serializer_class = SociProductSerializer
     queryset = SociProduct.objects.all()
 
-    @swagger_auto_schema(operation_summary="List SociProducts")
+    @swagger_auto_schema(
+        tags=['Soci Products'],
+        operation_summary="List SociProducts"
+    )
     def get(self, request, *args, **kwargs):
         soci_products = self.get_queryset()
         serializer = self.get_serializer(soci_products, many=True)
@@ -30,15 +34,17 @@ class SociBankAccountBalanceDetailView(RetrieveAPIView):
     """
     Checks the available balance of an account, based on the provided RFID card number.
     """
+    queryset = SociBankAccount.objects.all()
     serializer_class = CheckBalanceSerializer
 
     @swagger_auto_schema(
+        tags=['Soci Bank Accounts'],
         operation_summary="Retrieve SociBankAccount balance",
         manual_parameters=[Parameter(
-            name='card-number',
-            in_=IN_HEADER,
+            name='card_uuid',
+            in_=IN_QUERY,
             description="The RFID card id connected to a user's Soci bank account",
-            type=TYPE_INTEGER,
+            type=TYPE_STRING,
             required=True
         )],
         responses={
@@ -47,8 +53,7 @@ class SociBankAccountBalanceDetailView(RetrieveAPIView):
         },
     )
     def get(self, request, *args, **kwargs):
-        card_uuid = self.request.META.get('HTTP_CARD_NUMBER', None)
-        soci_bank_account: SociBankAccount = self._get_account_from_card_id(card_uuid=card_uuid)
+        soci_bank_account = self.get_object()
         serializer = self.get_serializer(soci_bank_account)
         data = serializer.data
 
@@ -58,28 +63,28 @@ class SociBankAccountBalanceDetailView(RetrieveAPIView):
 
         return Response(data, status=response_status)
 
-    @staticmethod
-    def _get_account_from_card_id(card_uuid) -> SociBankAccount:
-        soci_bank_account = get_object_or_404(queryset=SociBankAccount.objects.all(), card_uuid=card_uuid)
+    def get_object(self) -> SociBankAccount:
+        card_uuid = self.request.query_params.get('card_uuid', None)
+        if card_uuid is None:
+            raise ValidationError("You need to provide a card uuid as a query parameter.")
 
-        return soci_bank_account
+        return get_object_or_404(queryset=self.get_queryset(), card_uuid=card_uuid)
 
 
-class ChargeSociBankAccountView(CustomCreateAPIView):
+class SociBankAccountChargeView(CustomCreateAPIView):
     """
     Charges the specified account for the total amount of the products associated with provided SKU numbers.
     If the SKU is the direct charge, a direct charge amount needs to be provided as well.
     """
+    queryset = SociBankAccount.objects.all()
+    lookup_url_kwarg = 'id'
     deserializer_class = ChargeSociBankAccountDeserializer
     serializer_class = PurchaseSerializer
 
     @swagger_auto_schema(
+        tags=['Soci Bank Accounts'],
         request_body=deserializer_class(many=True),
         operation_summary="Charge SociBankAccount",
-        manual_parameters=[Parameter(
-            name='card-number', in_=IN_HEADER, description="The RFID card id connected to a user's Soci bank account",
-            type=TYPE_INTEGER, required=True
-        )],
         responses={
             "201": serializer_class,
             "400": ": Illegal input",
@@ -88,8 +93,7 @@ class ChargeSociBankAccountView(CustomCreateAPIView):
         },
     )
     def post(self, request, *args, **kwargs):
-        card_uuid = self.request.META.get('HTTP_CARD_NUMBER', None)
-        soci_bank_account: SociBankAccount = self._get_account_from_card_id(card_uuid=card_uuid)
+        soci_bank_account: SociBankAccount = self.get_object()
 
         deserializer = self.get_deserializer(
             data=request.data, context={'soci_bank_account': soci_bank_account}, many=True, allow_empty=False)
@@ -103,9 +107,3 @@ class ChargeSociBankAccountView(CustomCreateAPIView):
         data = serializer.data
 
         return Response(data, status=status.HTTP_201_CREATED)
-
-    @staticmethod
-    def _get_account_from_card_id(card_uuid) -> SociBankAccount:
-        soci_bank_account = get_object_or_404(queryset=SociBankAccount.objects.all(), card_uuid=card_uuid)
-
-        return soci_bank_account


### PR DESCRIPTION
* Send the card number in query params instead of as a custom http header
* Return bank account id from balance endpoint, which can be used to perform the charge
* Change URL formatting for charge to perform the operations on a specific bank account
* Update tests