### PR TITLE
Add more common semester-shorthand utilities

### DIFF
--- a/common/tests/tests.py
+++ b/common/tests/tests.py
@@ -1,13 +1,18 @@
+from datetime import datetime
+
 from django.template import Template, Context
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 
-from common.util import get_semester_year_shorthand
+from common.util import get_semester_year_shorthand, get_semester_year_shorthands_by_date, \
+    get_semester_year_shorthands_by_count, get_semester_date_boundaries_from_shorthand, is_valid_semester_year_shorthand
 from common.views import index
 from internal.views import index as internal_index
 from login.views import login_user
 from users.tests.factories import UserFactory
+
+from unittest.mock import patch
 
 
 class TestIndexView(TestCase):
@@ -75,3 +80,274 @@ class TestGetSemesterYearShortHandFilter(TestCase):
         with self.assertRaises(ValueError):
             context = Context({'timestamp': []})
             output = self.template.render(context)
+
+
+class TestGetSemesterYearShortHand(TestCase):
+    def test_get_semester_year_shorthand__timestamp_in_spring__returns_v_prefix_and_correct_year(self):
+        timestamp = timezone.datetime(year=2018, month=3, day=1)
+        self.assertEqual(get_semester_year_shorthand(timestamp), "V18")
+
+    def test_get_semester_year_shorthand__timestamp_in_autumn__returns_h_prefix_and_correct_year(self):
+        timestamp = timezone.datetime(year=2018, month=8, day=1)
+        self.assertEqual(get_semester_year_shorthand(timestamp), "H18")
+
+
+class TestGetSemesterYearShortHandFilter(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.template = Template("""
+            {% load ksg_helpers %} 
+            {{ timestamp | get_semester_year_shorthand }}
+        """)
+
+    def test_get_semester_year_shorthand_filter__timestamp_in_spring__returns_v_prefix_and_correct_year(self):
+        timestamp = timezone.datetime(year=2018, month=3, day=1)
+        context = Context({'timestamp': timestamp})
+        output = self.template.render(context)
+        self.assertEqual(output.strip(), "V18")
+
+
+    def test_get_semester_year_shorthand_filter__timestamp_in_autumn__returns_h_prefix_and_correct_year(self):
+        timestamp = timezone.datetime(year=2018, month=8, day=1)
+        context = Context({'timestamp': timestamp})
+        output = self.template.render(context)
+        self.assertEqual(output.strip(), "H18")
+
+    def test_get_semester_year_shorthand_filter__bad_input_type__throws(self):
+        with self.assertRaises(ValueError):
+            context = Context({'timestamp': 25})
+            output = self.template.render(context)
+
+        with self.assertRaises(ValueError):
+            # Sorry, strings doesn't work either
+            context = Context({'timestamp': "2018-01-01T22:22:22Z"})
+            output = self.template.render(context)
+
+        with self.assertRaises(ValueError):
+            context = Context({'timestamp': []})
+            output = self.template.render(context)
+
+
+class TestGetSemesterYearShorthandsByDate(TestCase):
+    def test_get_semester_year_shorthands_by_date__argument_is_in_this_semester__returns_array_with_this_semester_only(self):
+        # Patch timezone now, so we can make reliable tests without re-implementing the
+        # method itself in the test
+        with patch(
+                'django.utils.timezone.now',
+                return_value=datetime(2018, 1, 1, tzinfo=timezone.utc)
+        ):
+            date = timezone.datetime(2018, 1, 1, tzinfo=timezone.utc)
+            results = get_semester_year_shorthands_by_date(date)
+            self.assertListEqual(
+                results,
+                ["V18"]
+            )
+
+    def test_get_semester_year_shorthands_by_date__argument_is_5_semesters_back__returns_correct_result(self):
+        with patch(
+                'django.utils.timezone.now',
+                return_value=datetime(2018, 1, 1, tzinfo=timezone.utc)
+        ):
+            date = timezone.datetime(2016, 1, 1, tzinfo=timezone.utc)
+            results = get_semester_year_shorthands_by_date(date)
+            self.assertListEqual(
+                results,
+                ["V18", "H17", "V17", "H16", "V16"]
+            )
+
+    def test_get_semester_year_shorthands_by_date__argument_is_in_the_future__returns_empty_list(self):
+        with patch(
+                'django.utils.timezone.now',
+                return_value=datetime(2018, 1, 1, tzinfo=timezone.utc)
+        ):
+            date = timezone.datetime(2019, 1, 1, tzinfo=timezone.utc)
+            results = get_semester_year_shorthands_by_date(date)
+            self.assertListEqual(
+                results,
+                []
+            )
+
+    def test_get_semester_year_shorthands_by_date__argument_is_around_century_change__returns_correct_result(self):
+        with patch(
+                'django.utils.timezone.now',
+                return_value=datetime(2001, 1, 1, tzinfo=timezone.utc)
+        ):
+            date = timezone.datetime(1999, 1, 1, tzinfo=timezone.utc)
+            results = get_semester_year_shorthands_by_date(date)
+            self.assertListEqual(
+                results,
+                ["V01", "H00", "V00", "H99", "V99"]
+            )
+
+
+class TestGetSemesterYearShorthandsByCount(TestCase):
+
+    def test_get_semester_year_shorthands_by_count__argument_is_one__returns_correct_result(self):
+        # Patch timezone now, so we can make reliable tests without re-implementing the
+        # method itself in the test
+        with patch(
+                'django.utils.timezone.now',
+                return_value=datetime(2018, 1, 1, tzinfo=timezone.utc)
+        ):
+            results = get_semester_year_shorthands_by_count(1)
+            self.assertListEqual(
+                results,
+                ["V18"]
+            )
+
+    def test_get_semester_year_shorthands_by_count__regular_positive_integer__returns_correct_result(self):
+        with patch(
+                'django.utils.timezone.now',
+                return_value=datetime(2018, 1, 1, tzinfo=timezone.utc)
+        ):
+            results = get_semester_year_shorthands_by_count(5)
+            self.assertListEqual(
+                results,
+                ["V18", "H17", "V17", "H16", "V16"]
+            )
+
+    def test_get_semester_year_shorthands_by_count__negative_integer__returns_empty_list(self):
+        results = get_semester_year_shorthands_by_count(-1)
+        self.assertListEqual(results, [])
+
+    def test_get_semester_year_shorthands_by_count__timezone_now_around_century_change__returns_correct_result(self):
+        # This test simultaneously tests that we can render numbers 0-9 with leading zeros
+        # and that we handle the century change.
+
+        with patch(
+                'django.utils.timezone.now',
+                return_value=datetime(2001, 1, 1, tzinfo=timezone.utc)
+        ):
+            results = get_semester_year_shorthands_by_count(5)
+            self.assertListEqual(
+                results,
+                ["V01", "H00", "V00", "H99", "V99"]
+            )
+
+
+
+class TestGetSemesterDateBoundariesFromShorthand(TestCase):
+    def test_get_semester_date_boundaries_from_shorthand__input_in_spring_and_2000s__returns_correct_result(self):
+        start, end = get_semester_date_boundaries_from_shorthand("V18")
+        expected_tzinfo = timezone.now().tzinfo
+        self.assertEqual(
+            start,
+            timezone.datetime(
+                2018,
+                1,
+                1,
+                tzinfo=expected_tzinfo
+            )
+        )
+        self.assertEqual(
+            end,
+            timezone.datetime(
+                2018,
+                7,
+                1,
+                tzinfo=expected_tzinfo
+            )
+        )
+
+    def test_get_semester_date_boundaries_from_shorthand__input_in_autumn_and_2000s__returns_correct_result(self):
+        start, end = get_semester_date_boundaries_from_shorthand("H18")
+        expected_tzinfo = timezone.now().tzinfo
+        self.assertEqual(
+            start,
+            timezone.datetime(
+                2018,
+                7,
+                1,
+                tzinfo=expected_tzinfo
+            )
+        )
+        self.assertEqual(
+            end,
+            timezone.datetime(
+                2019,
+                1,
+                1,
+                tzinfo=expected_tzinfo
+            )
+        )
+
+    def test_get_semester_date_boundaries_from_shorthand__input_in_spring_and_1900s__returns_correct_result(self):
+        start, end = get_semester_date_boundaries_from_shorthand("V99")
+        expected_tzinfo = timezone.now().tzinfo
+        self.assertEqual(
+            start,
+            timezone.datetime(
+                1999,
+                1,
+                1,
+                tzinfo=expected_tzinfo
+            )
+        )
+        self.assertEqual(
+            end,
+            timezone.datetime(
+                1999,
+                7,
+                1,
+                tzinfo=expected_tzinfo
+            )
+        )
+
+    def test_get_semester_date_boundaries_from_shorthand__input_in_autumn_and_1900s__returns_correct_result(self):
+        start, end = get_semester_date_boundaries_from_shorthand("H99")
+        expected_tzinfo = timezone.now().tzinfo
+        self.assertEqual(
+            start,
+            timezone.datetime(
+                1999,
+                7,
+                1,
+                tzinfo=expected_tzinfo
+            )
+        )
+        self.assertEqual(
+            end,
+            timezone.datetime(
+                2000,
+                1,
+                1,
+                tzinfo=expected_tzinfo
+            )
+        )
+
+    def test_get_semester_date_boundaries_from_shorthand__invalid_input__raises_valueerror(self):
+        with self.assertRaises(ValueError):
+            get_semester_date_boundaries_from_shorthand("Kebab")
+
+        with self.assertRaises(ValueError):
+            get_semester_date_boundaries_from_shorthand("H0")
+
+        with self.assertRaises(ValueError):
+            get_semester_date_boundaries_from_shorthand("H1999")
+
+
+class TestIsValidSemesterYearShorthand(TestCase):
+    def test_is_valid_semester_year_shorthand__valid_spring_input__returns_true(self):
+        self.assertTrue(is_valid_semester_year_shorthand("V18"))
+        self.assertTrue(is_valid_semester_year_shorthand("V99"))
+        self.assertTrue(is_valid_semester_year_shorthand("V05"))
+        self.assertTrue(is_valid_semester_year_shorthand("V00"))
+
+    def test_is_valid_semester_year_shorthand__valid_autumn_input__returns_true(self):
+        self.assertTrue(is_valid_semester_year_shorthand("H18"))
+        self.assertTrue(is_valid_semester_year_shorthand("H99"))
+        self.assertTrue(is_valid_semester_year_shorthand("H05"))
+        self.assertTrue(is_valid_semester_year_shorthand("H00"))
+
+    def test_is_valid_semester_year_shorthand__invalid_input__returns_false(self):
+        self.assertFalse(is_valid_semester_year_shorthand("H0"))
+        self.assertFalse(is_valid_semester_year_shorthand("V0"))
+        self.assertFalse(is_valid_semester_year_shorthand("H013"))
+        self.assertFalse(is_valid_semester_year_shorthand("V013"))
+        self.assertFalse(is_valid_semester_year_shorthand("H1999"))
+        self.assertFalse(is_valid_semester_year_shorthand("V1999"))
+        self.assertFalse(is_valid_semester_year_shorthand("HV199"))
+        self.assertFalse(is_valid_semester_year_shorthand("VV199"))
+        self.assertFalse(is_valid_semester_year_shorthand("Kebab"))
+        self.assertFalse(is_valid_semester_year_shorthand("A18"))
+

--- a/common/util.py
+++ b/common/util.py
@@ -1,5 +1,8 @@
+import re
 from datetime import datetime, date
-from typing import Union
+from typing import Union, List, Tuple
+
+from django.utils import timezone
 
 
 def get_semester_year_shorthand(timestamp: Union[datetime, date]) -> str:
@@ -14,3 +17,149 @@ def get_semester_year_shorthand(timestamp: Union[datetime, date]) -> str:
     short_year_format = str(timestamp.year)[2:]
     semester_prefix = "H" if timestamp.month > 7 else "V"
     return f"{semester_prefix}{short_year_format}"
+
+
+def get_semester_year_shorthands_by_date(timestamp: Union[datetime, date]) -> List[str]:
+    """
+    get_semester_year_shorthands_by_date gets a list of semester-year shorthands backwards
+    in time. The earliest shorthand is defined by the semester the given timestamp occurs in.
+
+    Example:
+        timestamp = 12/04/2015, timezone.now → 25/05/2018
+        result: [
+            "V18",
+            "H17",
+            "V17",
+            "H16",
+            "V16",
+            "H15",
+            "V15"
+        ]
+
+    :param timestamp:
+    :return:
+    """
+    now = timezone.now()
+    current_semester_shorthand = get_semester_year_shorthand(now)
+    target_semester_shorthand = get_semester_year_shorthand(timestamp)
+
+    semester, year = current_semester_shorthand[0], int(current_semester_shorthand[1:])
+    target_semester, target_year = target_semester_shorthand[0], int(target_semester_shorthand[1:])
+
+    if timestamp.year > now.year or (timestamp.year == now.year and target_semester < semester):  # H < V alphabetically, and hence in the comparison
+        return []
+
+    results = [current_semester_shorthand]
+    while semester != target_semester or year != target_year:
+        year = year if semester == "H" else 99 if year == 0 else year - 1
+        semester = "V" if semester == "H" else "H"
+        results.append(
+            f"{semester}{str(year).zfill(2)}"
+        )
+
+    return results
+
+
+def get_semester_year_shorthands_by_count(number: int) -> List[str]:
+    """
+    get_semester_year_shorthands_by_count returns `number` amount of semester-year shorthands
+    backwards in time.
+
+    Example:
+        number = 3, timezone.now → 25/05/2018
+        result: ["V18", "H17", "V17"]
+
+    :param number:
+    :return:
+    """
+    if number <= 0:
+        return []
+
+    current_semester_shorthand = get_semester_year_shorthand(timezone.now())
+    semester, year = current_semester_shorthand[0], int(current_semester_shorthand[1:])
+
+    results = [current_semester_shorthand]
+
+    while number > 1:
+        number -= 1
+        year = year if semester == "H" else 99 if year == 0 else year - 1
+        semester = "V" if semester == "H" else "H"
+        results.append(
+            f"{semester}{str(year).zfill(2)}"
+        )
+
+    return results
+
+
+def get_semester_date_boundaries_from_shorthand(shorthand: str) -> Tuple[datetime, datetime]:
+    """
+    get_semester_date_boundaries_from_shorthand takes a semester-year shorthand string,
+    e.g. "H18", and returns the date boundaries of the semester.
+
+    This method assumes year values less than 90 refer to the twentyfirst century, and values
+    greater than 90 refer to the twentieth century.
+
+    Example:
+        shorthand = H18
+        result: datetime(2018, 7, 1), datetime(2019, 1, 1)
+
+        shorthand = V99
+        result: datetime(1999, 7, 1), datetime(2000, 1, 1)
+
+    :param shorthand:
+    :return:
+    """
+    if not is_valid_semester_year_shorthand(shorthand):
+        raise ValueError("Input to get_semester_date_boundaries_from_shorthand not a proper "
+                         "semester-year shorthand string.")
+
+    semester, year = shorthand[0], int(shorthand[1:])
+
+    if year > 90:
+        year += 1900
+    else:
+        year += 2000
+
+    # Get tzinfo
+    tzinfo = timezone.now().tzinfo
+
+    return (
+        timezone.datetime(
+            year=year,
+            month=1 if semester == "V" else 7,
+            day=1,
+            tzinfo=tzinfo
+        ),
+        timezone.datetime(
+            year=year+1 if semester == "H" else year,
+            month=1 if semester == "H" else 7,
+            day=1,
+            tzinfo=tzinfo
+        )
+    )
+
+
+def is_valid_semester_year_shorthand(shorthand: str) -> bool:
+    """
+    is_valid_semester_year_shorthand checks whether or not an input string is a valid
+    semester-year shorthand string.
+
+    Examples:
+        shorthand = H18
+        result: True
+
+        shorthand = H9
+        result: False
+
+        shorthand = H09
+        result: True
+
+        shorthand: Kebab
+        result: False
+    :param shorthand:
+    :return:
+    """
+    if len(shorthand) != 3:
+        return False
+
+    return re.match(r'[HV]\d{2}', shorthand) is not None


### PR DESCRIPTION
This commit is cherrypicked from #48, but is needed in other branches before the completion of that PR.

* get_semester_date_boundaries_from_shorthand takes a semester-year
shorhand string, e.g. "H18", and returns the date boundaries of the
semester.
* is_valid_semester_year_shorthand validates that a semester-year
shorthand string, e.g. "H18", is correct.
* get_semester_year_shorthands_by_count returns a number of
semester-year shorthands backwards in time, starting from now. The input
count determines the amount of shorthands returned.
* get_semester_year_shorthands_by_date returns a number of semester-year
shorthands backwards in time, starting from now. The input date
determines the last shorthand that should be included.