### PR TITLE
Update pipfile hashes

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -108,7 +108,9 @@
         },
         "inflection": {
             "hashes": [
-                "sha256:18ea7fb7a7d152853386523def08736aa8c32636b047ade55f7578c4edeb16ca"
+                "sha256:18ea7fb7a7d152853386523def08736aa8c32636b047ade55f7578c4edeb16ca",
+                "sha256:2695304262f62a3cfeeec54d1ea9bc8828a1a99e0678734c9a1b6437b7bdd153",
+                "sha256:8aab45d99f264e1ba11cb8b57a5597411d68399c7888a8743f9a11242fc1bcf3"
             ],
             "version": "==0.3.1"
         },
@@ -340,7 +342,8 @@
         },
         "docopt": {
             "hashes": [
-                "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+                "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491",
+                "sha256:dac3e317c3549bd112f0b4f47e31596d56f85f0f426c4993507f0c22e55fa631"
             ],
             "version": "==0.6.2"
         },


### PR DESCRIPTION
pythonanywhere includes certain pre-installed packages. I have included those packages' hashes in the pipenv lockfile so we can use pipenv in the pythonanywhere installation as well.