### PR TITLE
Refactor obtain JWT view to accept card uuid

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from rest_framework import serializers
-from rest_framework.exceptions import AuthenticationFailed
 from rest_framework_simplejwt.serializers import TokenObtainSlidingSerializer
 
 from api.exceptions import InsufficientFundsException, NoSociSessionError
@@ -14,16 +13,25 @@ class CustomTokenObtainSlidingSerializer(TokenObtainSlidingSerializer):
     username_field = SociBankAccount.card_uuid.field_name
 
     def __init__(self, *args, **kwargs):
+        """
+        Overridden from `TokenObtainSerializer` since this adds a required
+        field `password` to the serializer that we don't need.
+        """
         super().__init__(*args, **kwargs)
         del self.fields['password']
 
     def validate(self, attrs):
-        self.user = self.context['request'].user
+        """
+        Overridden from `TokenObtainSlidingSerializer` since
+        this expects a username and password to be supplied.
+        """
+        data = {}
 
-        if self.user is None or not self.user.is_active:
-            raise AuthenticationFailed
+        token = self.get_token(self.context['request'].user)
 
-        return {'token': str(self.get_token(self.user))}
+        data['token'] = str(token)
+
+        return data
 
 
 # ===============================

--- a/api/views.py
+++ b/api/views.py
@@ -2,20 +2,24 @@ import jwt
 from django.utils import timezone
 from drf_yasg.openapi import Parameter, IN_QUERY, TYPE_STRING
 from drf_yasg.utils import swagger_auto_schema
-from rest_framework import status
+from rest_framework import status, permissions
 from rest_framework.exceptions import ValidationError
 from rest_framework.generics import ListAPIView, RetrieveAPIView, get_object_or_404, DestroyAPIView
 from rest_framework.response import Response
 from rest_framework_simplejwt.views import TokenObtainSlidingView, TokenRefreshSlidingView, TokenVerifyView
 
 from api.serializers import CheckBalanceSerializer, SociProductSerializer, ChargeSociBankAccountDeserializer, \
-    PurchaseSerializer
+    PurchaseSerializer, CustomTokenObtainSlidingSerializer
 from api.view_mixins import CustomCreateAPIView
 from economy.models import SociBankAccount, SociProduct, Purchase, SociSession
+from ksg_nett.custom_authentication import CardNumberAuthentication
 
 
 class CustomTokenObtainSlidingView(TokenObtainSlidingView):
     swagger_schema = None
+    serializer_class = CustomTokenObtainSlidingSerializer
+    authentication_classes = [CardNumberAuthentication]
+    permission_classes = (permissions.IsAuthenticated,)
 
     def post(self, request, *args, **kwargs):
         response = super().post(request, *args, **kwargs)

--- a/economy/tests/factories.py
+++ b/economy/tests/factories.py
@@ -1,6 +1,6 @@
 import pytz
 from django.utils import timezone
-from factory import DjangoModelFactory, SubFactory, Faker, sequence, Sequence, post_generation
+from factory import DjangoModelFactory, SubFactory, Faker, Sequence, post_generation
 from factory.django import ImageField
 
 from economy.models import SociBankAccount, SociProduct, ProductOrder, Purchase, SociSession, Transfer, Deposit, \
@@ -15,11 +15,7 @@ class SociBankAccountFactory(DjangoModelFactory):
 
     user = SubFactory(UserFactory)
     balance = 0
-
-    @sequence
-    def card_uuid(n):
-        fake_number = Faker('ean13').evaluate(None, None, {})
-        return fake_number[9:] + str(n)
+    card_uuid = Faker('ean')
 
 
 class SociProductFactory(DjangoModelFactory):

--- a/ksg_nett/custom_authentication.py
+++ b/ksg_nett/custom_authentication.py
@@ -7,7 +7,7 @@ from rest_framework.exceptions import AuthenticationFailed
 User = get_user_model()
 
 
-class UsernameOrEmailOrCardNumberAuthenticationBackend(ModelBackend):
+class UsernameOrEmailAuthenticationBackend(ModelBackend):
     """
     Enables authenticating through either username or email
     """
@@ -15,8 +15,7 @@ class UsernameOrEmailOrCardNumberAuthenticationBackend(ModelBackend):
     # noinspection PyPep8Naming
     def authenticate(self, _request, username=None, password=None, **_kwargs):
         try:
-            user = User.objects.get(
-                Q(username__iexact=username) | Q(email__iexact=username) | Q(bank_account__card_uuid=username))
+            user = User.objects.get(Q(username__iexact=username) | Q(email__iexact=username))
         except User.DoesNotExist:
             return None
 
@@ -38,7 +37,7 @@ class CardNumberAuthentication(BaseAuthentication):
         """
 
         try:
-            user = User.objects.get(bank_account__card_uuid=request.data.get('card_uuid'))
+            user = User.objects.get(bank_account__card_uuid=request.data.get('card_uuid'), is_active=True)
         except User.DoesNotExist:
             raise AuthenticationFailed
 

--- a/ksg_nett/custom_authentication.py
+++ b/ksg_nett/custom_authentication.py
@@ -1,20 +1,45 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
 from django.db.models import Q
+from rest_framework.authentication import BaseAuthentication
+from rest_framework.exceptions import AuthenticationFailed
+
+User = get_user_model()
 
 
 class UsernameOrEmailOrCardNumberAuthenticationBackend(ModelBackend):
     """
-    Enables authenticating through either username, email or card number
+    Enables authenticating through either username or email
     """
 
     # noinspection PyPep8Naming
     def authenticate(self, _request, username=None, password=None, **_kwargs):
-        User = get_user_model()
-        username = username.lower()
         try:
-            user = User.objects.get(Q(username=username) | Q(email=username) | Q(bank_account__card_uuid=username))
+            user = User.objects.get(
+                Q(username__iexact=username) | Q(email__iexact=username) | Q(bank_account__card_uuid=username))
         except User.DoesNotExist:
             return None
 
         return user if self.user_can_authenticate(user) and user.check_password(password) else None
+
+
+class CardNumberAuthentication(BaseAuthentication):
+    """
+    Enables authenticating through only a card number.
+    This is used for starting Soci session by scanning a card.
+    """
+
+    def authenticate(self, request):
+        """
+        "To implement a custom authentication scheme, subclass BaseAuthentication and override the
+        .authenticate(self, request) method. The method should return a two-tuple of (user, auth) if authentication
+        succeeds, or None otherwise."
+        (source: https://www.django-rest-framework.org/api-guide/authentication/#custom-authentication)
+        """
+
+        try:
+            user = User.objects.get(bank_account__card_uuid=request.data.get('card_uuid'))
+        except User.DoesNotExist:
+            raise AuthenticationFailed
+
+        return user, None

--- a/ksg_nett/settings.py
+++ b/ksg_nett/settings.py
@@ -127,7 +127,7 @@ if not DEBUG:
 AUTH_USER_MODEL = 'users.User'
 
 AUTHENTICATION_BACKENDS = [
-    'ksg_nett.custom_authentication.UsernameOrEmailOrCardNumberAuthenticationBackend'
+    'ksg_nett.custom_authentication.UsernameOrEmailAuthenticationBackend'
 ]
 
 # Default login_required return url


### PR DESCRIPTION
In order to allow starting Soci sessions by only scanning a card, we need to refactor the obtain JWT view since it by default expects a username + password.

I have overridden the default behaviour so we can supply a `card_uuid` argument. I have also updated the tests for this view.