### PR TITLE
remove business logic from economy models

### DIFF
--- a/economy/models.py
+++ b/economy/models.py
@@ -242,12 +242,6 @@ class Deposit(TimeStampedModel):
     def __repr__(self):
         return f"Deposit(person={self.account.user},amount={self.amount})"
 
-    def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
-        if self.is_valid and not self.signed_off_time:
-            self.account.add_funds(self.amount)
-
-        super().save(force_insert=force_insert, force_update=force_update, using=using, update_fields=update_fields)
-
 
 class DepositComment(TimeStampedModel):
     """

--- a/economy/models.py
+++ b/economy/models.py
@@ -173,13 +173,6 @@ class ProductOrder(models.Model):
     def __repr__(self):
         return f"Order(product={self.product}, order_size={self.order_size})"
 
-    def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
-        if self._state.adding:
-            self.source.remove_funds(amount=self.cost)
-            SociBankAccount.soci_master_account.get().add_funds(amount=self.cost)
-
-        super().save(force_insert=force_insert, force_update=force_update, using=using, update_fields=update_fields)
-
 
 class Transfer(TimeStampedModel):
     """

--- a/economy/tests/tests.py
+++ b/economy/tests/tests.py
@@ -81,33 +81,6 @@ class ProductOrderTest(TestCase):
         self.assertEqual(expected_cost, self.product_order.cost)
 
 
-class DepositTest(TestCase):
-    def setUp(self):
-        self.valid_deposit = DepositFactory()
-
-    def test__approve_deposit__mark_as_valid_and_transfer_funds(self):
-        invalid_deposit = DepositFactory(signed_off_by=None)
-        self.assertFalse(invalid_deposit.is_valid)
-        self.assertIsNone(invalid_deposit.signed_off_time)
-        self.assertEqual(0, invalid_deposit.account.balance)
-
-        invalid_deposit.signed_off_by = UserFactory()
-        invalid_deposit.save()
-
-        self.assertTrue(invalid_deposit.is_valid)
-        self.assertIsNotNone(invalid_deposit.signed_off_time)
-        self.assertEqual(invalid_deposit.amount, invalid_deposit.account.balance)
-
-    def test__update_approved_deposit__do_not_transfer_funds_again(self):
-        original_amount = self.valid_deposit.amount
-        self.assertEqual(original_amount, self.valid_deposit.account.balance)
-
-        self.valid_deposit.amount = 1337
-        self.valid_deposit.save()
-
-        self.assertEqual(original_amount, self.valid_deposit.account.balance)
-
-
 class DepositCommentTest(TestCase):
     def setUp(self):
         self.deposit_comment = DepositCommentFactory()


### PR DESCRIPTION
Branched out from #148 closes #149 

Removes business logic from save methods in two of the economy models. Changes to account balances and whatnot should be dealt with in the app views instead of have loosely coupled logic all over the place