### PR TITLE
fix image size breaking landing page layout

### DIFF
--- a/internal/static/internal/css/frontpage.css
+++ b/internal/static/internal/css/frontpage.css
@@ -124,12 +124,15 @@
     100% {left: -400%; }
     } 
 
-div#slider { 
+div#slider {
+    height: 500px;
+    display: inline-block;
     overflow: hidden; 
 }
 
 div#slider figure img { 
-    width: 20%; 
+    width: 20%;
+    height: auto;
     float: left; 
 }
 


### PR DESCRIPTION
Closes #182

Commit summary:
- Fix the height so dimensions of images to not rule the container
size resulting in breaking the placement of other elements in
the document
